### PR TITLE
refactor: update blog links in layout components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
           </Typography.H4>
         </div>
         <div className="flex justify-center mt-8">
-          <Link href="https://blog.naver.com/youthfinlab" target="_blank">
+          <Link href="/blog">
             <Button variant="default">자세히 보기</Button>
           </Link>
         </div>

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -21,8 +21,7 @@ const Footer: FC = () => {
           {/* 메뉴 링크 */}
           <div className="flex flex-col md:flex-row gap-3">
             <Link
-              href="https://blog.naver.com/youthfinlab"
-              target="_blank"
+              href="/blog"
               className="text-gray-300 hover:text-white transition-colors"
             >
               블로그

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -24,9 +24,7 @@ const Header = () => {
         {/* 데스크톱 네비게이션 */}
         <nav className="hidden md:flex items-center space-x-6 text-sm font-medium">
           {/* 블로그는 외부링크 */}
-          <Link href="https://blog.naver.com/youthfinlab" target="_blank">
-            블로그
-          </Link>
+          <Link href="/blog">블로그</Link>
           <Link href="/customer-support">고객지원</Link>
           <Link href="/education-inquiry">
             <Button>교육문의</Button>


### PR DESCRIPTION
This pull request updates several links in the application to point to an internal blog page instead of an external blog. The changes are made across multiple components to ensure consistency in navigation.

Updates to internal links:

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L31-R31): Changed the blog link in the `Home` component to point to the internal `/blog` page instead of the external Naver blog.
* [`components/Layout/Footer.tsx`](diffhunk://#diff-40525301eeb74d881dfa8b063da228115aca007df4494ad00b5862e5d9205774L24-R24): Updated the blog link in the `Footer` component to use the internal `/blog` page.
* [`components/Layout/Header.tsx`](diffhunk://#diff-b63814957b08bfe4c6f7a5914ffcaed10c7e490250a7b2776cd9fdae3a08e3abL27-R27): Modified the blog link in the `Header` component to direct to the internal `/blog` page.- Changed external blog links to internal routing for better navigation.